### PR TITLE
Feature/prevent cell overwrite

### DIFF
--- a/assets/js/pages/index.js
+++ b/assets/js/pages/index.js
@@ -36,7 +36,6 @@ selectSquare(positionNumber) {
 }
 
 postNewMark(requestedMove) {
-  console.log("about to post a new mark", this.state.moves)
     axios.post('/api/create_move', {
         headers: {"Content-Type": "application/json"},
         data: {
@@ -64,7 +63,7 @@ postNewMark(requestedMove) {
         this.setState({error: errorMessage});
         setTimeout(()=> this.removeErrorMessage(), 1000);
       }
-    })
+    });
 }
 
 removeErrorMessage() {

--- a/assets/js/pages/index.js
+++ b/assets/js/pages/index.js
@@ -32,18 +32,11 @@ componentDidMount() {
 }
 
 selectSquare(positionNumber) {
-    const moves = this.state.moves;
-
-    if (!moves[positionNumber]) {
-        moves[positionNumber] = this.state.currentPlayer;
-        this.postNewMark(positionNumber);
-    } else {
-        this.setState({error: "Oh no, select an empty space!"});
-        setTimeout(()=> this.removeErrorMessage(), 1000);
-    }
+  this.postNewMark(positionNumber);
 }
 
 postNewMark(requestedMove) {
+  console.log("about to post a new mark", this.state.moves)
     axios.post('/api/create_move', {
         headers: {"Content-Type": "application/json"},
         data: {
@@ -53,17 +46,25 @@ postNewMark(requestedMove) {
             incomingMove: requestedMove
         }
     }).then((response) => {
-        let data = response.data;
-        let boardData = data.board;
-        let gameStatus = data.game_status;
-        let currentPlayer = data.current_player;
-        this.setState({
-            gameStatus: gameStatus,
-            moves: Object.assign(this.state.moves, boardData),
-            currentPlayer: currentPlayer,
-            message: currentPlayer == "X" ? "Player one," : "Player two," 
-        });
-    }).catch(error => console.log(error));
+      let data = response.data;
+      let boardData = data.board;
+      let gameStatus = data.game_status;
+      let currentPlayer = data.current_player;
+      this.setState({
+          gameStatus: gameStatus,
+          moves: Object.assign(this.state.moves, boardData),
+          currentPlayer: currentPlayer,
+          message: currentPlayer == "X" ? "Player one," : "Player two," 
+      });
+    }).catch(error => {
+      let errorCode = error.response.status;
+      let errorMessage = error.response.data;
+
+      if(errorCode == 400) {
+        this.setState({error: errorMessage});
+        setTimeout(()=> this.removeErrorMessage(), 1000);
+      }
+    })
 }
 
 removeErrorMessage() {

--- a/lib/tic_tac_toe/board.ex
+++ b/lib/tic_tac_toe/board.ex
@@ -8,10 +8,14 @@ defmodule TicTacToe.Board do
     end
 
     def get_board_moves(board) do
-        Enum.map(board, fn {_key, val} -> val end )
+        Enum.map(board, fn {key, _val} -> key end )
     end
 
     def current_marks(board) do
         Enum.map(0..8, fn x -> board[x] || :empty end)
+    end
+
+    def valid_move?(board, cell) do
+        Map.get(board, cell) == nil
     end
 end

--- a/lib/tic_tac_toe_web/controllers/game_controller.ex
+++ b/lib/tic_tac_toe_web/controllers/game_controller.ex
@@ -2,6 +2,7 @@ defmodule TicTacToeWeb.GameController do
     use TicTacToeWeb, :controller
     
     alias TicTacToe.Game, as: Game
+    alias TicTacToe.Board, as: Board
 
     def new_game(connection, _params) do
         game = Game.setup_new_game
@@ -15,7 +16,7 @@ defmodule TicTacToeWeb.GameController do
     
     def send_board_update_response(updated_game, connection, _params) do
         body = Jason.encode!(updated_game)
-
+        
         connection  
         |> put_status(200)
         |> text(body)
@@ -37,11 +38,34 @@ defmodule TicTacToeWeb.GameController do
         end
     end
 
+    def validate_move(current_board, incoming_move) do
+        parsed_move = to_string(incoming_move)
+
+        case (Board.valid_move?(current_board, parsed_move)) do
+            true -> 
+                {:ok, "Move is valid"}
+            false -> 
+                {:error, "Move is invalid"}
+        end
+    end
+
+    def handle_error(connection) do
+        connection
+        |> put_status(400)
+        |> text("Oh no, that spot is already taken!")
+    end
+
     def create_move(connection, _params) do
-        fetch_board_update_request(connection)
-        |> json_to_map
-        |> Game.make_move
-        |> send_board_update_response(connection, _params)
+        data = fetch_board_update_request(connection)
+        mapped_data = json_to_map(data)
+        
+        case validate_move(mapped_data.board, mapped_data.incoming_move) do
+            {:ok, "Move is valid"} ->
+                Game.make_move(mapped_data)
+                |> send_board_update_response(connection, _params)
+            {:error, "Move is invalid"} -> 
+                handle_error(connection)
+        end
     end
 
 end

--- a/lib/tic_tac_toe_web/controllers/game_controller.ex
+++ b/lib/tic_tac_toe_web/controllers/game_controller.ex
@@ -27,15 +27,13 @@ defmodule TicTacToeWeb.GameController do
         Map.fetch(response, "data")
     end
 
-    def json_to_map(contents) do
-        case (contents) do
-            {:ok, data} -> %{
-                board: data["board"],
-                current_player: data["currentPlayer"],
-                game_status: data["gameStatus"],
-                incoming_move: data["incomingMove"]
-            }
-        end
+    def json_to_map({:ok, data}) do
+        %{
+            board: data["board"],
+            current_player: data["currentPlayer"],
+            game_status: data["gameStatus"],
+            incoming_move: data["incomingMove"]
+        }
     end
 
     def validate_move(current_board, incoming_move) do

--- a/test/board_test.exs
+++ b/test/board_test.exs
@@ -49,7 +49,7 @@ defmodule BoardTest do
             board_1 = Board.update(Board.empty_board, 0, :player_one)
             board_2 = Board.update(board_1, 1, :player_two)
         
-            assert board_2 = %{player_one: 0, player_two: 1}
+            assert board_2 = %{0 => :player_one, 1 => :player_two}
             assert Board.get_board_moves(board_2) == [0,1]
         end
     end
@@ -82,6 +82,28 @@ defmodule BoardTest do
                                                     :empty,
                                                     :empty,
                                                     :player_two]
+        end
+    end
+
+    describe "valid_move?" do
+        test "returns true if move is not already on the board" do
+            board_1 = %{0 => "X", 3 => "O", 6 => "X"}
+            board_2 = %{3 => "X", 4 => "O", 5 => "X"}
+            board_3 = %{6 => "X", 7 => "O"}
+
+            assert Board.valid_move?(board_1, 1) == true
+            assert Board.valid_move?(board_2, 2) == true
+            assert Board.valid_move?(board_3, 4) == true
+        end
+
+        test "returns false if move is already on the board" do
+            board_1 = %{0 => "X", 3 => "O", 6 => "X"}
+            board_2 = %{3 => "X", 4 => "O", 5 => "X"}
+            board_3 = %{6 => "X", 7 => "O"}
+
+            assert Board.valid_move?(board_1, 0) == false
+            assert Board.valid_move?(board_2, 3) == false
+            assert Board.valid_move?(board_3, 7) == false
         end
     end
   end

--- a/test/tic_tac_toe_web/controllers/game_controller_test.exs
+++ b/test/tic_tac_toe_web/controllers/game_controller_test.exs
@@ -71,4 +71,36 @@ defmodule TicTacToeWeb.GameControllerTest do
                                                    }
         end
     end
+
+    describe "validate_move" do
+        test " returns ok when incoming move of 2 is valid" do
+            board = %{"1" => "X", "5" => "O"}
+            move = 2
+
+            assert Controller.validate_move(board, move) == {:ok, "Move is valid"}
+        end
+
+        test " returns ok when incoming move of 6 is valid" do
+            board = %{"1" => "X", "5" => "O"}
+            move = 6
+
+            assert Controller.validate_move(board, move) == {:ok, "Move is valid"}
+        end
+
+        test " returns error when incoming move is unavailable" do
+            board = %{"1" => "X", "5" => "O"}
+            move = 1
+
+            assert Controller.validate_move(board, move) == {:error, "Move is invalid"}
+        end
+    end
+
+    describe "handle_error" do
+        test " returns 400 when incoming move is not available", %{conn: conn} do
+            conn = build_conn(:post, "/api/createmove", "Oh no, that spot is already taken!")
+            call = Controller.handle_error(conn)
+            
+            assert call.resp_body == "Oh no, that spot is already taken!"
+        end
+    end
 end


### PR DESCRIPTION
[Here](https://trello.com/c/0Ehi6mY9/20-prevent-previously-marked-cells-from-being-overwritten) is the story for this PR. 

New features: 
- Player turn switching is handled by the server and sent to the client
- Cell overwrite prevention is handled by the server instead of the client
- When a previously selected cell is selected again, the server sends a 400 response and error message

![giphy-prevent](https://user-images.githubusercontent.com/21062007/56011614-118c8f00-5cae-11e9-9339-6404b5cbd2df.gif)


